### PR TITLE
Add comments for time entries

### DIFF
--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -56,7 +56,7 @@ class Redmine {
    * @param {Callable} callback
    */
   taskEntryFromToggl(data, callback) {
-    let descriptionMatch = (data.description || '').match(/#(\d+)\s?(.+)?/);
+    let descriptionMatch = (data.description || '').match(/#(\d+):?(.+)?/);
 
     if (!descriptionMatch) {
       callback('Time entry description is invalid');
@@ -67,7 +67,7 @@ class Redmine {
       'issue_id': descriptionMatch[1],
       'spent_on': data.start.match(/^[^T]+/)[0],
       'hours': (data.duration * 1.2 / 3600).toFixed(1),
-      'comments': descriptionMatch.length === 3 ? descriptionMatch[2] : '',
+      'comments': descriptionMatch[2] ? descriptionMatch[2] : '',
       'activity_id': FIELD_ACTIVITY_DEFAULT_VALUE,
       'custom_field_values': {
         [FIELD_TYPE_ID]: FIELD_TYPE_DEFAULT_VALUE,

--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -56,7 +56,7 @@ class Redmine {
    * @param {Callable} callback
    */
   taskEntryFromToggl(data, callback) {
-    let descriptionMatch = (data.description || '').match(/#(\d+):?(.+)?/);
+    let descriptionMatch = (data.description || '').match(/#(\d+)(\s*:\s*(.+))?/);
 
     if (!descriptionMatch) {
       callback('Time entry description is invalid');
@@ -67,7 +67,7 @@ class Redmine {
       'issue_id': descriptionMatch[1],
       'spent_on': data.start.match(/^[^T]+/)[0],
       'hours': (data.duration * 1.2 / 3600).toFixed(1),
-      'comments': descriptionMatch[2] ? descriptionMatch[2] : '',
+      'comments': descriptionMatch[3] ? descriptionMatch[3] : '',
       'activity_id': FIELD_ACTIVITY_DEFAULT_VALUE,
       'custom_field_values': {
         [FIELD_TYPE_ID]: FIELD_TYPE_DEFAULT_VALUE,

--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -56,7 +56,7 @@ class Redmine {
    * @param {Callable} callback
    */
   taskEntryFromToggl(data, callback) {
-    let descriptionMatch = (data.description || '').match(/#(\d+)/);
+    let descriptionMatch = (data.description || '').match(/#(\d+)\s?(.+)?/);
 
     if (!descriptionMatch) {
       callback('Time entry description is invalid');
@@ -67,6 +67,7 @@ class Redmine {
       'issue_id': descriptionMatch[1],
       'spent_on': data.start.match(/^[^T]+/)[0],
       'hours': (data.duration * 1.2 / 3600).toFixed(1),
+      'comments': descriptionMatch.length === 3 ? descriptionMatch[2] : '',
       'activity_id': FIELD_ACTIVITY_DEFAULT_VALUE,
       'custom_field_values': {
         [FIELD_TYPE_ID]: FIELD_TYPE_DEFAULT_VALUE,


### PR DESCRIPTION
Any character you add after #IssueID and one whitespace will be added as comment for timeEntries.